### PR TITLE
[Feat] Auth API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,6 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from './modules/prisma/prisma.module';
 
 @Module({
-  imports: [ConfigurationModule, PrismaModule, CommonModule, V1Module],
+  imports: [ConfigurationModule, CommonModule, PrismaModule, V1Module],
 })
 export class AppModule {}

--- a/src/common/constants/responseMessage.ts
+++ b/src/common/constants/responseMessage.ts
@@ -47,6 +47,7 @@ export default {
   UNAUTHORIZED_USER: '유효하지 않은 유저입니다.',
   NO_USER: '탈퇴했거나 가입하지 않은 유저입니다.',
   NO_USER_ID: '존재하지 않는 유저 Id입니다.',
+  NO_USER_UUID: '존재하지 않는 유저의 uuid 값입니다.',
   SEARCH_USER_FAIL: '해당 닉네임을 포함하는 유저가 존재하지 않습니다.',
   UPDATE_USER_DEVICE: '유저 디바이스 등록 성공',
 };

--- a/src/common/constants/swagger/domain/auth/AuthLoginSuccess.ts
+++ b/src/common/constants/swagger/domain/auth/AuthLoginSuccess.ts
@@ -1,0 +1,20 @@
+import { AuthResponseDTO } from '@modules/v1/auth/dto/auth.res.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { CREATED_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class AuthLoginSuccess extends PickType(CREATED_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '로그인 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: AuthResponseDTO,
+  })
+  data: AuthResponseDTO;
+}

--- a/src/common/constants/swagger/domain/auth/AuthSignupSuccess.ts
+++ b/src/common/constants/swagger/domain/auth/AuthSignupSuccess.ts
@@ -1,0 +1,20 @@
+import { AuthResponseDTO } from '@modules/v1/auth/dto/auth.res.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { CREATED_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class AuthSignupSuccess extends PickType(CREATED_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '소셜 회원가입 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: AuthResponseDTO,
+  })
+  data: AuthResponseDTO;
+}

--- a/src/common/constants/swagger/domain/auth/AuthTokenGetAccepted.ts
+++ b/src/common/constants/swagger/domain/auth/AuthTokenGetAccepted.ts
@@ -1,0 +1,13 @@
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { ACCEPTED_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class AuthTokenGetAccepted extends PickType(ACCEPTED_TYPE, ['status'] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '토큰이 유효합니다.',
+    description: '토큰이 유효하여 재발급하지 않습니다.',
+  })
+  message: string;
+}

--- a/src/common/constants/swagger/domain/auth/AuthTokenGetSuccess.ts
+++ b/src/common/constants/swagger/domain/auth/AuthTokenGetSuccess.ts
@@ -1,0 +1,20 @@
+import { AuthTokenGetResDTO } from '@modules/v1/auth/dto/auth-token-get.res.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class AuthTokenGetSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '토큰 재발급 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: AuthTokenGetResDTO,
+  })
+  data: AuthTokenGetResDTO;
+}

--- a/src/common/constants/swagger/domain/auth/AuthWithdrawSuccess.ts
+++ b/src/common/constants/swagger/domain/auth/AuthWithdrawSuccess.ts
@@ -1,0 +1,14 @@
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class AuthWithdrawSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '회원 탈퇴 성공',
+  })
+  message: string;
+}

--- a/src/common/exceptions/http-exception.filter.ts
+++ b/src/common/exceptions/http-exception.filter.ts
@@ -1,4 +1,9 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from '@nestjs/common';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
 import { Response } from 'express';
 
 @Catch(HttpException)
@@ -7,7 +12,9 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const status = exception.getStatus();
-    const error = exception.getResponse() as string | { error: string; status: number; message: string | string[] };
+    const error = exception.getResponse() as
+      | string
+      | { error: string; status: number; message: string | string[] };
 
     if (typeof error === 'string') {
       response.status(status).json({

--- a/src/config/common.module.ts
+++ b/src/config/common.module.ts
@@ -1,3 +1,4 @@
+import { DataValidatorService } from '@helper/data-validator.service';
 import { Global, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
@@ -6,7 +7,14 @@ import { ApiConfigService } from './services/api-config.service';
 import { AwsS3Service } from './services/aws-s3.service';
 import { JwtHandlerService } from './services/jwt-handler.service';
 
-const providers = [ApiConfigService, AwsS3Service, ConfigService, JwtHandlerService, JwtService];
+const providers = [
+  ApiConfigService,
+  AwsS3Service,
+  ConfigService,
+  JwtHandlerService,
+  JwtService,
+  DataValidatorService,
+];
 
 @Global()
 @Module({

--- a/src/modules/v1/auth/auth.controller.ts
+++ b/src/modules/v1/auth/auth.controller.ts
@@ -1,8 +1,10 @@
 import { rm } from '@common/constants';
 import { ResponseEntity } from '@common/constants/responseEntity';
+import { AuthLoginSuccess } from '@common/constants/swagger/domain/auth/AuthLoginSuccess';
 import { AuthSignupSuccess } from '@common/constants/swagger/domain/auth/AuthSignupSuccess';
 import { ConflictError } from '@common/constants/swagger/error/ConflictError';
 import { InternalServerError } from '@common/constants/swagger/error/InternalServerError';
+import { NotFoundError } from '@common/constants/swagger/error/NotFoundError';
 import { UnauthorizedError } from '@common/constants/swagger/error/UnauthorizedError';
 import {
   Body,
@@ -20,6 +22,7 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { AuthLoginRequestDTO } from './dto/auth-login.req.dto';
 import { AuthSignupRequestDTO } from './dto/auth-signup.req.dto';
 import { AuthResponseDTO } from './dto/auth.res.dto';
 
@@ -67,6 +70,40 @@ export class AuthController {
     );
 
     return ResponseEntity.CREATED_WITH_DATA(rm.SIGNUP_SUCCESS, data);
+  }
+
+  //todo 로그인
+  @ApiOperation({
+    summary: '로그인을 진행합니다.',
+    description: ``,
+  })
+  @ApiOkResponse({
+    description: '로그인에 성공했습니다.',
+    type: AuthLoginSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiConflictResponse({
+    description: '존재하지 않는 유저입니다.',
+    type: NotFoundError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Post('/login')
+  async login(
+    @Body() body: AuthLoginRequestDTO,
+  ): Promise<ResponseEntity<AuthResponseDTO>> {
+    const uuid = await this.authService.getUuidFromSocialToken(
+      body.provider,
+      body.token,
+    );
+
+    const data = await this.authService.login(uuid);
+    return ResponseEntity.OK_WITH_DATA(rm.SIGNIN_SUCCESS, data);
   }
 
   //todo 토큰 재발급

--- a/src/modules/v1/auth/auth.controller.ts
+++ b/src/modules/v1/auth/auth.controller.ts
@@ -4,30 +4,39 @@ import { AuthLoginSuccess } from '@common/constants/swagger/domain/auth/AuthLogi
 import { AuthSignupSuccess } from '@common/constants/swagger/domain/auth/AuthSignupSuccess';
 import { AuthTokenGetAccepted } from '@common/constants/swagger/domain/auth/AuthTokenGetAccepted';
 import { AuthTokenGetSuccess } from '@common/constants/swagger/domain/auth/AuthTokenGetSuccess';
+import { AuthWithdrawSuccess } from '@common/constants/swagger/domain/auth/AuthWithdrawSuccess';
 import { BadRequestError } from '@common/constants/swagger/error/BadRequestError';
 import { ConflictError } from '@common/constants/swagger/error/ConflictError';
 import { InternalServerError } from '@common/constants/swagger/error/InternalServerError';
 import { NotFoundError } from '@common/constants/swagger/error/NotFoundError';
 import { UnauthorizedError } from '@common/constants/swagger/error/UnauthorizedError';
+import { Token } from '@common/decorators/token.decorator';
+import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Headers,
   Inject,
   Logger,
   LoggerService,
   Post,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiAcceptedResponse,
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiConflictResponse,
   ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { UserDTO } from '../user/dto/user.dto';
 import { AuthService } from './auth.service';
 import { AuthLoginRequestDTO } from './dto/auth-login.req.dto';
 import { AuthSignupRequestDTO } from './dto/auth-signup.req.dto';
@@ -35,6 +44,7 @@ import { AuthTokenGetHeaderDTO } from './dto/auth-token-get.header.dto';
 import { AuthResponseDTO } from './dto/auth.res.dto';
 
 @Controller('auth')
+@ApiTags('Auth API')
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
@@ -154,4 +164,33 @@ export class AuthController {
   }
 
   //todo 회원 탈퇴
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: '회원 탈퇴',
+    description: `
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '회원 탈퇴 성공',
+    type: AuthWithdrawSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiNotFoundResponse({
+    description: '존재하지 않는 유저의 id입니다.',
+    type: NotFoundError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류입니다.',
+    type: InternalServerError,
+  })
+  @Delete()
+  @ApiBearerAuth('Authorization')
+  async deleteUser(@Token() user: UserDTO) {
+    await this.authService.withdraw(user.id);
+    return ResponseEntity.OK_WITH(rm.DELETE_USER_SUCCESS);
+  }
 }

--- a/src/modules/v1/auth/auth.controller.ts
+++ b/src/modules/v1/auth/auth.controller.ts
@@ -1,5 +1,27 @@
-import { Controller, Inject, Logger, LoggerService } from '@nestjs/common';
+import { rm } from '@common/constants';
+import { ResponseEntity } from '@common/constants/responseEntity';
+import { AuthSignupSuccess } from '@common/constants/swagger/domain/auth/AuthSignupSuccess';
+import { ConflictError } from '@common/constants/swagger/error/ConflictError';
+import { InternalServerError } from '@common/constants/swagger/error/InternalServerError';
+import { UnauthorizedError } from '@common/constants/swagger/error/UnauthorizedError';
+import {
+  Body,
+  Controller,
+  Inject,
+  Logger,
+  LoggerService,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiConflictResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { AuthSignupRequestDTO } from './dto/auth-signup.req.dto';
+import { AuthResponseDTO } from './dto/auth.res.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -8,7 +30,45 @@ export class AuthController {
     @Inject(Logger) private readonly logger: LoggerService,
   ) {}
 
-  //todo 소셜 회원가입 및 로그인
+  //todo 소셜 회원가입
+  @ApiOperation({
+    summary: '회원가입을 진행합니다.',
+    description: ``,
+  })
+  @ApiOkResponse({
+    description: '회원가입에 성공했습니다.',
+    type: AuthSignupSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiConflictResponse({
+    description: '이미 사용중인 닉네임입니다.',
+    type: ConflictError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Post('/signup')
+  async signup(
+    @Body() body: AuthSignupRequestDTO,
+  ): Promise<ResponseEntity<AuthResponseDTO>> {
+    const uuid = await this.authService.getUuidFromSocialToken(
+      body.provider,
+      body.token,
+    );
+
+    const data = await this.authService.signup(
+      body.provider,
+      uuid,
+      body.nickname,
+    );
+
+    return ResponseEntity.CREATED_WITH_DATA(rm.SIGNUP_SUCCESS, data);
+  }
+
   //todo 토큰 재발급
   //todo 회원 탈퇴
 }

--- a/src/modules/v1/auth/auth.controller.ts
+++ b/src/modules/v1/auth/auth.controller.ts
@@ -2,6 +2,9 @@ import { rm } from '@common/constants';
 import { ResponseEntity } from '@common/constants/responseEntity';
 import { AuthLoginSuccess } from '@common/constants/swagger/domain/auth/AuthLoginSuccess';
 import { AuthSignupSuccess } from '@common/constants/swagger/domain/auth/AuthSignupSuccess';
+import { AuthTokenGetAccepted } from '@common/constants/swagger/domain/auth/AuthTokenGetAccepted';
+import { AuthTokenGetSuccess } from '@common/constants/swagger/domain/auth/AuthTokenGetSuccess';
+import { BadRequestError } from '@common/constants/swagger/error/BadRequestError';
 import { ConflictError } from '@common/constants/swagger/error/ConflictError';
 import { InternalServerError } from '@common/constants/swagger/error/InternalServerError';
 import { NotFoundError } from '@common/constants/swagger/error/NotFoundError';
@@ -9,12 +12,16 @@ import { UnauthorizedError } from '@common/constants/swagger/error/UnauthorizedE
 import {
   Body,
   Controller,
+  Get,
+  Headers,
   Inject,
   Logger,
   LoggerService,
   Post,
 } from '@nestjs/common';
 import {
+  ApiAcceptedResponse,
+  ApiBadRequestResponse,
   ApiConflictResponse,
   ApiInternalServerErrorResponse,
   ApiOkResponse,
@@ -24,6 +31,7 @@ import {
 import { AuthService } from './auth.service';
 import { AuthLoginRequestDTO } from './dto/auth-login.req.dto';
 import { AuthSignupRequestDTO } from './dto/auth-signup.req.dto';
+import { AuthTokenGetHeaderDTO } from './dto/auth-token-get.header.dto';
 import { AuthResponseDTO } from './dto/auth.res.dto';
 
 @Controller('auth')
@@ -107,5 +115,43 @@ export class AuthController {
   }
 
   //todo 토큰 재발급
+  @ApiOperation({
+    summary: '토큰 재발급',
+    description: `
+    access 토큰과 refresh 토큰이 모두 만료된 경우에 토큰을 재발급 합니다. \n
+    토큰이 유효한 경우엔 202를 출력합니다. \n
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '토큰 재발급 성공',
+    type: AuthTokenGetSuccess,
+  })
+  @ApiAcceptedResponse({
+    description: '토큰이 유효한 경우 Accepted 처리됩니다.',
+    type: AuthTokenGetAccepted,
+  })
+  @ApiBadRequestResponse({
+    description: '잘못된 요청 값입니다.',
+    type: BadRequestError,
+  })
+  @ApiUnauthorizedResponse({
+    description: '유효하지 않은 유저 / 토큰입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Get('/token')
+  async refreshToken(@Headers() header: AuthTokenGetHeaderDTO) {
+    const data = await this.authService.renewalToken(
+      header.accesstoken,
+      header.refreshtoken,
+    );
+    if (!data) return ResponseEntity.ACCEPTED_WITH(rm.VALID_TOKEN);
+    return ResponseEntity.OK_WITH_DATA(rm.CREATE_TOKEN_SUCCESS, data);
+  }
+
   //todo 회원 탈퇴
 }

--- a/src/modules/v1/auth/auth.module.ts
+++ b/src/modules/v1/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthController } from './auth.controller';
 import { AUTH_REPOSITORY } from './auth.interface';
 import AuthRepository from './auth.repository';
 import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
 
 const AuthRepositoryProvider = {
   provide: AUTH_REPOSITORY,
@@ -22,6 +23,7 @@ const UserRepositoryProvider = {
     UserRepositoryProvider,
     AuthService,
     Logger,
+    JwtStrategy,
   ],
 })
 export class AuthModule {}

--- a/src/modules/v1/auth/auth.service.ts
+++ b/src/modules/v1/auth/auth.service.ts
@@ -15,6 +15,7 @@ import {
 import { AuthRepositoryInterface, AUTH_REPOSITORY } from './auth.interface';
 import { authStrategy } from './common/auth.strategy';
 import { AUTH, SocialPlatform } from './common/auth.type';
+import { AuthTokenGetResDTO } from './dto/auth-token-get.res.dto';
 import { AuthResponseDTO } from './dto/auth.res.dto';
 
 @Injectable()
@@ -80,7 +81,9 @@ export class AuthService {
 
       const user = await this.authRepository.findByRefreshToken(refreshToken);
       if (!user) throw new NotFoundException(rm.NO_USER_TOKEN);
-      return this.jwt.getAccessToken(user);
+
+      const newAccessToken = this.jwt.getAccessToken(user);
+      return new AuthTokenGetResDTO(newAccessToken);
     }
 
     const user = await this.userRepository.findById(decodedAccessToken.id);

--- a/src/modules/v1/auth/auth.service.ts
+++ b/src/modules/v1/auth/auth.service.ts
@@ -13,6 +13,7 @@ import {
   USER_REPOSITORY,
 } from '../user/interfaces/user-repository.interface';
 import { AuthRepositoryInterface, AUTH_REPOSITORY } from './auth.interface';
+import { authStrategy } from './common/auth.strategy';
 import { AUTH, SocialPlatform } from './common/auth.type';
 import { AuthResponseDTO } from './dto/auth.res.dto';
 
@@ -45,6 +46,9 @@ export class AuthService {
     const newRefreshToken = this.jwt.getRefreshToken();
     const existedUser = this.authRepository.findByUuid(uuid);
     if (existedUser) throw new ConflictException(rm.ALREADY_SIGNED_USER);
+
+    const alreadyUsedNickname = this.userRepository.findByNickname(nickname);
+    if (alreadyUsedNickname) throw new ConflictException(rm.ALREADY_USER_NAME);
 
     const user = await this.authRepository.create(
       social,
@@ -88,5 +92,10 @@ export class AuthService {
     if (!user) throw new NotFoundException(rm.NO_USER_ID);
 
     await this.authRepository.delete(userId);
+  }
+
+  async getUuidFromSocialToken(social: SocialPlatform, token: string) {
+    const user = await authStrategy[social].execute(token);
+    return user;
   }
 }

--- a/src/modules/v1/auth/auth.service.ts
+++ b/src/modules/v1/auth/auth.service.ts
@@ -45,10 +45,12 @@ export class AuthService {
 
   async signup(social: SocialPlatform, uuid: string, nickname: string) {
     const newRefreshToken = this.jwt.getRefreshToken();
-    const existedUser = this.authRepository.findByUuid(uuid);
+    const existedUser = await this.authRepository.findByUuid(uuid);
     if (existedUser) throw new ConflictException(rm.ALREADY_SIGNED_USER);
 
-    const alreadyUsedNickname = this.userRepository.findByNickname(nickname);
+    const alreadyUsedNickname = await this.userRepository.findByNickname(
+      nickname,
+    );
     if (alreadyUsedNickname) throw new ConflictException(rm.ALREADY_USER_NAME);
 
     const user = await this.authRepository.create(

--- a/src/modules/v1/auth/auth.service.ts
+++ b/src/modules/v1/auth/auth.service.ts
@@ -27,9 +27,9 @@ export class AuthService {
     private readonly jwt: JwtHandlerService,
   ) {}
 
-  async login(userId: number) {
-    const user = await this.userRepository.findById(userId);
-    if (!user) throw new NotFoundException(rm.NO_USER_ID);
+  async login(uuid: string) {
+    const user = await this.authRepository.findByUuid(uuid);
+    if (!user) throw new NotFoundException(rm.NO_USER_UUID);
 
     const jwtPayload: JwtPayload = { ...user };
     const newAccessToken = this.jwt.getAccessToken(jwtPayload);

--- a/src/modules/v1/auth/common/auth.strategy.ts
+++ b/src/modules/v1/auth/common/auth.strategy.ts
@@ -1,5 +1,5 @@
-import { AuthType, SocialAuthStrategy } from './auth.type';
 import { auth } from '../config/auth.config';
+import { AuthType, SocialAuthStrategy } from './auth.type';
 
 class GoogleAuthStrategy implements SocialAuthStrategy {
   constructor(private readonly auth: auth) {}
@@ -23,8 +23,16 @@ class AppleAuthStrategy implements SocialAuthStrategy {
   }
 }
 
+class NaverAuthStrategy implements SocialAuthStrategy {
+  constructor(private readonly auth: auth) {}
+  execute(accessToken: string): Promise<string> {
+    return this.auth.naverAuth(accessToken);
+  }
+}
+
 export const authStrategy: AuthType = {
   kakao: new KakaoAuthStrategy(new auth()),
   apple: new AppleAuthStrategy(new auth()),
   google: new GoogleAuthStrategy(new auth()),
+  naver: new NaverAuthStrategy(new auth()),
 };

--- a/src/modules/v1/auth/common/auth.type.ts
+++ b/src/modules/v1/auth/common/auth.type.ts
@@ -7,7 +7,7 @@ export enum AUTH {
   SIGNUP = 'SIGNUP',
 }
 
-export type SocialPlatform = 'kakao' | 'apple' | 'google';
+export type SocialPlatform = 'kakao' | 'apple' | 'google' | 'naver';
 
 export type AuthType = {
   [social in SocialPlatform]: SocialAuthStrategy;

--- a/src/modules/v1/auth/config/auth.config.ts
+++ b/src/modules/v1/auth/config/auth.config.ts
@@ -32,7 +32,8 @@ export class auth {
       const user = jwt.decode(appleAccessToken);
       const uuid = user.sub as string;
 
-      if (!uuid || !user) throw new UnauthorizedException(rm.UNAUTHORIZED_SOCIAL);
+      if (!uuid || !user)
+        throw new UnauthorizedException(rm.UNAUTHORIZED_SOCIAL);
 
       return uuid.toString();
     } catch (error) {
@@ -42,13 +43,36 @@ export class auth {
     }
   }
 
+  //* 네이버 OAuth 통신
+  async naverAuth(naverAccessToken: string): Promise<string> {
+    try {
+      const user = await axios({
+        method: 'get',
+        url: 'https://openapi.naver.com/v1/nid/me',
+        headers: {
+          Authorization: `Bearer ${naverAccessToken}`,
+        },
+      });
+
+      const uuid = user.data.response.id;
+
+      if (!uuid) throw new UnauthorizedException(rm.UNAUTHORIZED_SOCIAL);
+
+      return uuid.toString();
+    } catch (error) {
+      console.error(error);
+      throw new BadRequestException(rm.SIGNIN_FAIL);
+    }
+  }
+
   //* 구글 OAuth 통신
   async googleAuth(googleAccessToken: string): Promise<string> {
     try {
       const user = jwt.decode(googleAccessToken);
       const uuid = user.sub as string;
 
-      if (!uuid || !user) throw new UnauthorizedException(rm.UNAUTHORIZED_SOCIAL);
+      if (!uuid || !user)
+        throw new UnauthorizedException(rm.UNAUTHORIZED_SOCIAL);
 
       return uuid.toString();
     } catch (error) {

--- a/src/modules/v1/auth/dto/auth-login.req.dto.ts
+++ b/src/modules/v1/auth/dto/auth-login.req.dto.ts
@@ -1,0 +1,14 @@
+import { UserDTO } from '@modules/v1/user/dto/user.dto';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AuthLoginRequestDTO extends PickType(UserDTO, ['provider']) {
+  @ApiProperty({
+    example: 1,
+    description: '소셜 토큰 값입니다.',
+    required: true,
+  })
+  @IsNotEmpty({ message: '소셜 토큰 값은 필수입니다.' })
+  @IsString({ message: '소셜 토큰 값은 문자여야 합니다.' })
+  token: string;
+}

--- a/src/modules/v1/auth/dto/auth-signup.req.dto.ts
+++ b/src/modules/v1/auth/dto/auth-signup.req.dto.ts
@@ -1,0 +1,17 @@
+import { UserDTO } from '@modules/v1/user/dto/user.dto';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AuthSignupRequestDTO extends PickType(UserDTO, [
+  'provider',
+  'nickname',
+]) {
+  @ApiProperty({
+    example: 1,
+    description: '소셜 토큰 값입니다.',
+    required: true,
+  })
+  @IsNotEmpty({ message: '소셜 토큰 값은 필수입니다.' })
+  @IsString({ message: '소셜 토큰 값은 문자여야 합니다.' })
+  token: string;
+}

--- a/src/modules/v1/auth/dto/auth-token-get.header.dto.ts
+++ b/src/modules/v1/auth/dto/auth-token-get.header.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AuthTokenGetHeaderDTO {
+  @ApiProperty({
+    example: 'access token here',
+    description: 'Access 토큰 값입니다.',
+    required: true,
+  })
+  @IsNotEmpty({ message: 'Access 토큰은 필수입니다.' })
+  @IsString({ message: 'Access 토큰은 문자여야 합니다.' })
+  accesstoken: string;
+
+  @ApiProperty({
+    example: 'refresh token here',
+    description: 'Refresh 토큰 값입니다.',
+    required: true,
+  })
+  @IsNotEmpty({ message: 'Refresh 토큰은 필수입니다.' })
+  @IsString({ message: 'Refresh 토큰은 문자여야 합니다.' })
+  refreshtoken: string;
+}

--- a/src/modules/v1/auth/dto/auth-token-get.res.dto.ts
+++ b/src/modules/v1/auth/dto/auth-token-get.res.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+
+export class AuthTokenGetResDTO {
+  @ApiProperty() @Exclude() private readonly accessToken: string;
+
+  constructor(token: string) {
+    this.accessToken = token;
+  }
+
+  @Expose()
+  get getAccessToken(): string {
+    return this.accessToken;
+  }
+}

--- a/src/modules/v1/user/dto/user.dto.ts
+++ b/src/modules/v1/user/dto/user.dto.ts
@@ -1,3 +1,4 @@
+import { SocialPlatform } from '@modules/v1/auth/common/auth.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsDate, IsNumber, IsString } from 'class-validator';
 
@@ -15,7 +16,7 @@ export class UserDTO {
 
   @ApiProperty()
   @IsString()
-  provider: string;
+  provider: SocialPlatform;
 
   @ApiProperty()
   @IsString()

--- a/src/modules/v1/user/dto/user.dto.ts
+++ b/src/modules/v1/user/dto/user.dto.ts
@@ -31,8 +31,8 @@ export class UserDTO {
     required: true,
   })
   @IsString({ message: '소셜 값은 문자여야 합니다.' })
-  @IsIn(['kakao', 'apple', 'google'], {
-    message: `소셜 값은 'kakao', 'apple', 'google'만 사용 가능합니다.`,
+  @IsIn(['kakao', 'apple', 'naver', 'google'], {
+    message: `소셜 값은 'kakao', 'apple', 'naver', 'google'만 사용 가능합니다.`,
   })
   @IsNotEmpty({ message: '소셜 값은 필수입니다.' })
   provider: SocialPlatform;

--- a/src/modules/v1/user/dto/user.dto.ts
+++ b/src/modules/v1/user/dto/user.dto.ts
@@ -1,6 +1,15 @@
 import { SocialPlatform } from '@modules/v1/auth/common/auth.type';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsDate, IsNumber, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsDate,
+  IsIn,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class UserDTO {
   @ApiProperty({
@@ -10,17 +19,41 @@ export class UserDTO {
   @IsNumber()
   id: number;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: '유저의 uuid 값입니다.',
+    required: true,
+  })
   @IsString()
   uuid: string;
 
-  @ApiProperty()
-  @IsString()
+  @ApiProperty({
+    description: '유저가 가입한 소셜 플랫폼 경로입니다.',
+    required: true,
+  })
+  @IsString({ message: '소셜 값은 문자여야 합니다.' })
+  @IsIn(['kakao', 'apple', 'google'], {
+    message: `소셜 값은 'kakao', 'apple', 'google'만 사용 가능합니다.`,
+  })
+  @IsNotEmpty({ message: '소셜 값은 필수입니다.' })
   provider: SocialPlatform;
 
-  @ApiProperty()
-  @IsString()
+  @ApiProperty({
+    description: '유저의 닉네임입니다.',
+    required: true,
+  })
+  @IsString({ message: '유저의 닉네임은 문자열이여야 합니다.' })
+  @MinLength(1, { message: '닉네임은 1자 이상 10자 이하이여야 합니다' })
+  @MaxLength(10, { message: '닉네임은 1자 이상 10자 이하이여야 합니다' })
   nickname: string;
+
+  @ApiProperty({
+    description: 'Refresh 토큰 값입니다.',
+    required: true,
+    example: 'refresh token here',
+  })
+  @IsNotEmpty()
+  @IsString()
+  refreshToken: string;
 
   @ApiProperty()
   @IsDate()

--- a/src/modules/v1/user/user.controller.ts
+++ b/src/modules/v1/user/user.controller.ts
@@ -1,5 +1,6 @@
 import { rm } from '@common/constants';
 import { ResponseEntity } from '@common/constants/responseEntity';
+import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
 import {
   Body,
   Controller,
@@ -7,13 +8,15 @@ import {
   Logger,
   LoggerService,
   Patch,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { UserNicknamePatchReqDTO } from './dto/user-nickname.patch.req.dto';
 import { UserService } from './user.service';
 
+@ApiTags('User API')
 @Controller('user')
-@ApiTags('유저 API')
+@UseGuards(JwtAuthGuard)
 export class UserController {
   constructor(
     private readonly userService: UserService,

--- a/src/modules/v1/v1.module.ts
+++ b/src/modules/v1/v1.module.ts
@@ -1,8 +1,15 @@
 import { Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 
+const Modules = [UserModule, AuthModule];
+
+const ModulesForVersioning = Modules.map((module) => {
+  return { path: 'v1', module };
+});
+
 @Module({
-  imports: [UserModule, AuthModule],
+  imports: [...Modules, RouterModule.register(ModulesForVersioning)],
 })
 export class V1Module {}

--- a/test/v1/auth/unit/auth.service.test.ts
+++ b/test/v1/auth/unit/auth.service.test.ts
@@ -129,14 +129,16 @@ describe('AuthService 테스트', () => {
     let TEST_REFRESH_TOKEN = 'test_refresh_token';
 
     it(`로그인에 성공한 경우`, async () => {
-      when(await userRepository.findById(1)).thenReturn(createUser({ id: 1 }));
+      when(await authRepository.findByUuid('1')).thenReturn(
+        createUser({ id: 1, uuid: '1' }),
+      );
       when(jwt.getAccessToken(anything())).thenReturn(TEST_ACCESS_TOKEN);
       when(jwt.getRefreshToken()).thenReturn(TEST_REFRESH_TOKEN);
       when(
         await authRepository.updateRefreshToken(1, TEST_REFRESH_TOKEN),
       ).thenReturn(createUser({ id: 1, refresh_token: TEST_REFRESH_TOKEN }));
 
-      const result = await service.login(1);
+      const result = await service.login('1');
 
       expect(result.getAccessToken).toBe(TEST_ACCESS_TOKEN);
       expect(result.getRefreshToken).toBe(TEST_REFRESH_TOKEN);
@@ -144,14 +146,14 @@ describe('AuthService 테스트', () => {
     });
 
     it(`존재하지 않는 유저인 경우 NotFoundException이 발생한다.`, async () => {
-      when(await userRepository.findById(1)).thenReturn();
+      when(await authRepository.findByUuid('1')).thenReturn();
 
       const result = async () => {
-        await service.login(1);
+        await service.login('1');
       };
 
       expect(result).rejects.toThrowError(
-        new NotFoundException('존재하지 않는 유저 Id입니다.'),
+        new NotFoundException('존재하지 않는 유저의 uuid 값입니다.'),
       );
     });
   });

--- a/test/v1/auth/unit/auth.service.test.ts
+++ b/test/v1/auth/unit/auth.service.test.ts
@@ -107,6 +107,21 @@ describe('AuthService 테스트', () => {
         new ConflictException('이미 가입한 유저입니다.'),
       );
     });
+
+    it(`이미 사용중인 닉네임으로 회원가입을 시도한 경우 ConflictException이 발생한다.`, async () => {
+      when(await authRepository.findByUuid(TEST_UUID)).thenReturn();
+      when(await userRepository.findByNickname(TEST_NICKNAME)).thenReturn(
+        createUser({ nickname: TEST_NICKNAME }),
+      );
+
+      const result = async () => {
+        await service.signup(SOCIAL, TEST_UUID, TEST_NICKNAME);
+      };
+
+      expect(result).rejects.toThrowError(
+        new ConflictException('이미 사용중인 닉네임입니다.'),
+      );
+    });
   });
 
   describe(`✔️ 로그인 테스트`, () => {


### PR DESCRIPTION

## ✨ Pull Request
- [Feat] Auth API 구현

<br>

## 📦 Summary
- #11 
- #6 

<br>

## ✔️ Changed
- 회원가입 시 닉네임 중복 테스트 코드 추가 및 소셜 회원가입 API 구현
- 로그인 API 구현 및 해당 테스트 코드 일부 수정
- 토큰 재발급 API 구현
- API Versioning을 위해 V1Module 내부에 RouteModule 적용
- refreshToken 컬럼 추가로 UserDTO 수정
- Naver OAtuh 로직 구현