### PR TITLE
[feat] 캐릭터별 활동 조회 API 구현

### DIFF
--- a/src/common/constants/swagger/domain/activity/ActivityCharacterGetSuccess.ts
+++ b/src/common/constants/swagger/domain/activity/ActivityCharacterGetSuccess.ts
@@ -1,0 +1,21 @@
+import { ActivityDto } from '@modules/v1/activity/dto/activity.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class ActivityCharacterGetSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '활동 조회 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: ActivityDto,
+    isArray: true,
+  })
+  data: ActivityDto[];
+}

--- a/src/common/constants/swagger/domain/activity/ActivityCreateSuccess.ts
+++ b/src/common/constants/swagger/domain/activity/ActivityCreateSuccess.ts
@@ -1,0 +1,20 @@
+import { ActivityDto } from '@modules/v1/activity/dto/activity.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { CREATED_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class ActivityCreateSuccess extends PickType(CREATED_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '활동 생성 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: ActivityDto,
+  })
+  data: ActivityDto;
+}

--- a/src/common/constants/swagger/domain/activity/ActivityDeleteSuccess.ts
+++ b/src/common/constants/swagger/domain/activity/ActivityDeleteSuccess.ts
@@ -1,0 +1,14 @@
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class ActivityDeleteSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '활동 삭제 성공',
+  })
+  message: string;
+}

--- a/src/common/constants/swagger/domain/activity/ActivityUpdateSuccess.ts
+++ b/src/common/constants/swagger/domain/activity/ActivityUpdateSuccess.ts
@@ -1,0 +1,20 @@
+import { ActivityDto } from '@modules/v1/activity/dto/activity.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class ActivityUpdateSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '활동 수정 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: ActivityDto,
+  })
+  data: ActivityDto;
+}

--- a/src/config/routes.config.ts
+++ b/src/config/routes.config.ts
@@ -25,6 +25,7 @@ export const routesV1 = {
     root: ACTIVITY_ROOT,
     calender: `/${ACTIVITY_ROOT}/`,
     specificDate: `/${ACTIVITY_ROOT}/:date`,
+    character: `/${ACTIVITY_ROOT}/character/:character_id`,
     create: `/${ACTIVITY_ROOT}/`,
     update: `/${ACTIVITY_ROOT}/:activity_id`,
     delete: `/${ACTIVITY_ROOT}/:activity_id`,

--- a/src/modules/v1/activity/activity.controller.ts
+++ b/src/modules/v1/activity/activity.controller.ts
@@ -83,7 +83,7 @@ export class ActivityController {
 
   // todo 체크 필요
   @ApiOperation({
-    summary: '특정 일자의 캐릭터를 조회합니다.',
+    summary: '특정 일자의 캐츄를 조회합니다.',
     description: ``,
   })
   @ApiOkResponse({
@@ -111,14 +111,14 @@ export class ActivityController {
 
   //todo 체크 필요
   @ApiOperation({
-    summary: '특정 캐릭터의 활동들을 조회합니다.',
+    summary: '특정 캐츄의 활동들을 조회합니다.',
     description: `
-    Params로 특정 캐릭터의 id를 받고 해당 캐릭터로 작성했던 
+    Params로 특정 캐츄의 id를 받고 해당 캐츄로 작성했던 
     삭제되지 않은 모든 활동들을 조회합니다.
     `,
   })
   @ApiOkResponse({
-    description: '캐릭터 활동 조회에 성공했습니다.',
+    description: '캐츄 활동 조회에 성공했습니다.',
     type: UserPatchNicknameSuccess,
   })
   @ApiUnauthorizedResponse({

--- a/src/modules/v1/activity/activity.controller.ts
+++ b/src/modules/v1/activity/activity.controller.ts
@@ -33,6 +33,7 @@ import dayjs from 'dayjs';
 import CustomParseFormat from 'dayjs/plugin/customParseFormat';
 import { UserDTO } from '../user/dto/user.dto';
 import { ActivityService } from './activity.service';
+import { ActivityCharacterParamsDTO } from './dto/activity-character.params.dto';
 import { ActivityCreateRequestDto } from './dto/activity-create.req.dto';
 import { ActivityDateParamsDTO } from './dto/activity-date.params.dto';
 import { ActivityUpdateRequestDto } from './dto/activity-update.req.dto';
@@ -47,7 +48,6 @@ dayjs.extend(CustomParseFormat);
 export class ActivityController {
   constructor(private readonly activityService: ActivityService) {}
 
-  //todo [GET] 캘린더 조회
   @ApiOperation({
     summary: '날짜 범위 내의 캘린더 데이터를 조회합니다.',
     description: ``,
@@ -77,7 +77,6 @@ export class ActivityController {
     return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
   }
 
-  //todo [GET] 특정 일자 캐릭터 조회
   @ApiOperation({
     summary: '특정 일자의 캐릭터를 조회합니다.',
     description: ``,
@@ -106,7 +105,32 @@ export class ActivityController {
     return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
   }
 
-  //todo [POST] 활동 작성
+  @ApiOperation({
+    summary: '특정 캐릭터의 활동들을 조회합니다.',
+    description: ``,
+  })
+  @ApiOkResponse({
+    description: '캐릭터 활동 조회에 성공했습니다.',
+    type: UserPatchNicknameSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Get(routesV1.activity.character)
+  async getCharacterActivities(
+    @Param() params: ActivityCharacterParamsDTO,
+  ): Promise<ResponseEntity<any>> {
+    const data = await this.activityService.getActivitiesByCharacterId(
+      params.character_id,
+    );
+    return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
+  }
+
   @ApiImageFile('image')
   @ApiOperation({
     summary: '활동을 작성합니다.',

--- a/src/modules/v1/activity/activity.controller.ts
+++ b/src/modules/v1/activity/activity.controller.ts
@@ -1,5 +1,8 @@
 import { rm } from '@common/constants';
 import { ResponseEntity } from '@common/constants/responseEntity';
+import { ActivityCreateSuccess } from '@common/constants/swagger/domain/activity/ActivityCreateSuccess';
+import { ActivityDeleteSuccess } from '@common/constants/swagger/domain/activity/ActivityDeleteSuccess';
+import { ActivityUpdateSuccess } from '@common/constants/swagger/domain/activity/ActivityUpdateSuccess';
 import { UserPatchNicknameSuccess } from '@common/constants/swagger/domain/user/UserPatchNicknameSuccess';
 import { InternalServerError } from '@common/constants/swagger/error/InternalServerError';
 import { UnauthorizedError } from '@common/constants/swagger/error/UnauthorizedError';
@@ -32,6 +35,7 @@ import {
 import dayjs from 'dayjs';
 import CustomParseFormat from 'dayjs/plugin/customParseFormat';
 import { UserDTO } from '../user/dto/user.dto';
+import { ActivityCharacterGetSuccess } from './../../../common/constants/swagger/domain/activity/ActivityCharacterGetSuccess';
 import { ActivityService } from './activity.service';
 import { ActivityCharacterParamsDTO } from './dto/activity-character.params.dto';
 import { ActivityCreateRequestDto } from './dto/activity-create.req.dto';
@@ -54,7 +58,7 @@ export class ActivityController {
   })
   @ApiOkResponse({
     description: '캘린더 조회에 성공했습니다.',
-    type: UserPatchNicknameSuccess,
+    type: ActivityCharacterGetSuccess,
   })
   @ApiUnauthorizedResponse({
     description: '인증 되지 않은 요청입니다.',
@@ -77,13 +81,13 @@ export class ActivityController {
     return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
   }
 
+  // todo 체크 필요
   @ApiOperation({
     summary: '특정 일자의 캐릭터를 조회합니다.',
     description: ``,
   })
   @ApiOkResponse({
     description: '캘린더 조회에 성공했습니다.',
-    type: UserPatchNicknameSuccess,
   })
   @ApiUnauthorizedResponse({
     description: '인증 되지 않은 요청입니다.',
@@ -105,9 +109,13 @@ export class ActivityController {
     return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
   }
 
+  //todo 체크 필요
   @ApiOperation({
     summary: '특정 캐릭터의 활동들을 조회합니다.',
-    description: ``,
+    description: `
+    Params로 특정 캐릭터의 id를 받고 해당 캐릭터로 작성했던 
+    삭제되지 않은 모든 활동들을 조회합니다.
+    `,
   })
   @ApiOkResponse({
     description: '캐릭터 활동 조회에 성공했습니다.',
@@ -160,7 +168,7 @@ export class ActivityController {
   })
   @ApiCreatedResponse({
     description: '활동 작성에 성공했습니다.',
-    type: UserPatchNicknameSuccess,
+    type: ActivityCreateSuccess,
   })
   @ApiUnauthorizedResponse({
     description: '인증 되지 않은 요청입니다.',
@@ -187,7 +195,6 @@ export class ActivityController {
     return ResponseEntity.CREATED_WITH_DATA(rm.CREATE_ACTIVITY_SUCCESS, data);
   }
 
-  //todo [PATCH] 활동 수정
   @ApiOperation({
     summary: '특정 활동을 수정합니다.',
     description: `
@@ -212,7 +219,7 @@ export class ActivityController {
   })
   @ApiOkResponse({
     description: '활동 수정에 성공했습니다.',
-    type: UserPatchNicknameSuccess,
+    type: ActivityUpdateSuccess,
   })
   @ApiUnauthorizedResponse({
     description: '인증 되지 않은 요청입니다.',
@@ -241,7 +248,6 @@ export class ActivityController {
     return ResponseEntity.OK_WITH_DATA(rm.UPDATE_ACTIVITY_SUCCESS, data);
   }
 
-  //todo [DELETE] 활동 삭제
   @ApiOperation({
     summary: '특정 활동을 삭제합니다.',
     description: `
@@ -251,7 +257,7 @@ export class ActivityController {
   })
   @ApiOkResponse({
     description: '활동 삭제에 성공했습니다.',
-    type: UserPatchNicknameSuccess,
+    type: ActivityDeleteSuccess,
   })
   @ApiUnauthorizedResponse({
     description: '인증 되지 않은 요청입니다.',

--- a/src/modules/v1/activity/activity.controller.ts
+++ b/src/modules/v1/activity/activity.controller.ts
@@ -41,6 +41,7 @@ import { ActivityCharacterParamsDTO } from './dto/activity-character.params.dto'
 import { ActivityCreateRequestDto } from './dto/activity-create.req.dto';
 import { ActivityDateParamsDTO } from './dto/activity-date.params.dto';
 import { ActivityUpdateRequestDto } from './dto/activity-update.req.dto';
+import { ActivityDto } from './dto/activity.dto';
 import { ActivityParamsDto } from './dto/activity.params.dto';
 import { ActivityQueryDTO } from './dto/activity.query.dto';
 dayjs.extend(CustomParseFormat);
@@ -52,6 +53,7 @@ dayjs.extend(CustomParseFormat);
 export class ActivityController {
   constructor(private readonly activityService: ActivityService) {}
 
+  // todo 체크 필요
   @ApiOperation({
     summary: '날짜 범위 내의 캘린더 데이터를 조회합니다.',
     description: ``,
@@ -109,7 +111,6 @@ export class ActivityController {
     return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
   }
 
-  //todo 체크 필요
   @ApiOperation({
     summary: '특정 캐츄의 활동들을 조회합니다.',
     description: `
@@ -132,7 +133,7 @@ export class ActivityController {
   @Get(routesV1.activity.character)
   async getCharacterActivities(
     @Param() params: ActivityCharacterParamsDTO,
-  ): Promise<ResponseEntity<any>> {
+  ): Promise<ResponseEntity<ActivityDto[]>> {
     const data = await this.activityService.getActivitiesByCharacterId(
       params.character_id,
     );
@@ -183,7 +184,7 @@ export class ActivityController {
     @Token() user: UserDTO,
     @Body() body: ActivityCreateRequestDto,
     @UploadedFile() file?: any,
-  ): Promise<ResponseEntity<any>> {
+  ): Promise<ResponseEntity<ActivityDto>> {
     const url = file ? file.transforms[0].location : null;
     const data = await this.activityService.createActivity(
       user.id,
@@ -235,7 +236,7 @@ export class ActivityController {
     @Param() params: ActivityParamsDto,
     @UploadedFile() file: any,
     @Body() body: ActivityUpdateRequestDto,
-  ): Promise<ResponseEntity<any>> {
+  ): Promise<ResponseEntity<ActivityDto>> {
     const url = file.transforms[0].location;
     const data = await this.activityService.updateActivity(
       user.id,
@@ -253,6 +254,7 @@ export class ActivityController {
     description: `
     Params로 받은 index에 해당하는 활동 데이터를 삭제합니다. \n
     헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    삭제된 활동은 복구가 가능합니다.
     `,
   })
   @ApiOkResponse({
@@ -271,7 +273,7 @@ export class ActivityController {
   async deleteActivity(
     @Token() user: UserDTO,
     @Param() params: ActivityParamsDto,
-  ): Promise<ResponseEntity<any>> {
+  ): Promise<ResponseEntity<string>> {
     await this.activityService.deleteActivity(user.id, params.activity_id);
     return ResponseEntity.OK_WITH(rm.DELETE_ACTIVITY_SUCCESS);
   }

--- a/src/modules/v1/activity/activity.repository.ts
+++ b/src/modules/v1/activity/activity.repository.ts
@@ -33,6 +33,15 @@ export class ActivityRepository implements ActivityRepositoryInterface {
     });
   }
 
+  async findByCharacterId(characterId: number): Promise<Activity[]> {
+    return await this.prisma.activity.findMany({
+      where: {
+        character_id: characterId,
+        is_delete: false,
+      },
+    });
+  }
+
   async findBetweenDateAndDate(
     userId: number,
     startDate: Date,

--- a/src/modules/v1/activity/activity.service.ts
+++ b/src/modules/v1/activity/activity.service.ts
@@ -33,6 +33,10 @@ export class ActivityService {
     return await this.activityRepository.findByDate(userId, target);
   }
 
+  async getActivitiesByCharacterId(characterId: number) {
+    return await this.activityRepository.findByCharacterId(characterId);
+  }
+
   async createActivity(
     userId: number,
     characterId: number,

--- a/src/modules/v1/activity/dto/activity-character.params.dto.ts
+++ b/src/modules/v1/activity/dto/activity-character.params.dto.ts
@@ -1,0 +1,6 @@
+import { PickType } from '@nestjs/swagger';
+import { ActivityDto } from './activity.dto';
+
+export class ActivityCharacterParamsDTO extends PickType(ActivityDto, [
+  'character_id',
+]) {}

--- a/src/modules/v1/activity/interfaces/activity-repository.interface.ts
+++ b/src/modules/v1/activity/interfaces/activity-repository.interface.ts
@@ -11,6 +11,7 @@ export interface ActivityRepositoryInterface
     startDate: Date,
     endDate: Date,
   ): Promise<Activity[]>;
+  findByCharacterId(characterId: number): Promise<Activity[]>;
   create(
     userId: number,
     characterId: number,

--- a/src/modules/v1/character/dto/character-block.req.dto.ts
+++ b/src/modules/v1/character/dto/character-block.req.dto.ts
@@ -3,7 +3,7 @@ import { IsNumber } from 'class-validator';
 
 export class CharacterBlockRequestDTO {
   @ApiProperty({
-    description: '차단할 캐릭터의 id 값',
+    description: '차단할 캐츄의 id 값',
     required: true,
   })
   @IsNumber()

--- a/src/modules/v1/character/dto/character.dto.ts
+++ b/src/modules/v1/character/dto/character.dto.ts
@@ -11,7 +11,7 @@ import {
 
 export class CharacterDTO {
   @ApiProperty({
-    description: '캐릭터의 id 값',
+    description: '캐츄의 id 값',
     required: true,
   })
   @IsNumber()


### PR DESCRIPTION
## 📦 Summary
- 캐릭터별 활동 조회 API 구현

<br>

## ✔️ Changed
- 캐릭터별 활동 내역을 조회할 수 있는 API를 구현했습니다.
- Activity API에 Swagger 내용이 부실한 면이 있어서 추가 및 업데이트했습니다.
- 모든 API 공통적으로 Swagger 일부분에서 캐츄-캐릭터를 둘 다 사용하고 있어 혼동을 방지하기 위해 '캐츄'로 통일했습니다.
- 