### PR TITLE
[feat] 캐츄 둘러보기 완성

### DIFF
--- a/src/common/constants/responseMessage.ts
+++ b/src/common/constants/responseMessage.ts
@@ -68,7 +68,8 @@ export default {
   ALREADY_BLOCKED_CHARACTER: '이미 차단한 캐츄입니다.',
   BLOCK_CHARACTER_SUCCESS: '캐츄 차단 성공',
   READ_CHARACTERS_FROM_MAIN_SUCCESS: '캐츄 메인 목록 조회 성공',
-  READ_CHARACTERS_LIST_SUCCESS: '캐츄 메인 목록 조회 성공',
+  READ_CHARACTERS_LIST_SUCCESS: '캐츄 목록 조회 성공',
   READ_CHARACTER_DETAIL_SUCCESS: '캐츄 정보 조회 성공',
+  READ_CHARACTERS_FROM_LOOKING_SUCCESS: '캐츄 둘러보기 목록 조회 성공',
   NO_ACCESS_DELETE_CHARACTER: '다른 유저의 캐츄는 삭제할 수 없습니다.',
 };

--- a/src/common/constants/swagger/domain/character/CharacterGetFromLookingSuccess.ts
+++ b/src/common/constants/swagger/domain/character/CharacterGetFromLookingSuccess.ts
@@ -1,0 +1,21 @@
+import { CharactersGetLookingResponseDTO } from '@modules/v1/character/dto/characters-get-looking.res.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class CharacterGetLookingListSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '캐츄 둘러보기 목록 조회 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: [CharactersGetLookingResponseDTO],
+    title: '캐츄 목록',
+  })
+  data: CharactersGetLookingResponseDTO[];
+}

--- a/src/config/routes.config.ts
+++ b/src/config/routes.config.ts
@@ -37,6 +37,7 @@ export const routesV1 = {
     update: `/${CHARACTER_ROOT}/`,
     main: `/${CHARACTER_ROOT}/`,
     block: `/${CHARACTER_ROOT}/block`,
+    looking: `/${CHARACTER_ROOT}/looking`,
     list: `/${CHARACTER_ROOT}/list`,
     detail: `/${CHARACTER_ROOT}/detail/:character_id`,
     delete: `/${CHARACTER_ROOT}/:character_id`,

--- a/src/modules/v1/character/character.controller.ts
+++ b/src/modules/v1/character/character.controller.ts
@@ -3,6 +3,7 @@ import { ResponseEntity } from '@common/constants/responseEntity';
 import { CharacterBlockSuccess } from '@common/constants/swagger/domain/character/CharacterBlockSuccess';
 import { CharacterCreateSuccess } from '@common/constants/swagger/domain/character/CharacterCreateSuccess';
 import { CharacterEditSuccess } from '@common/constants/swagger/domain/character/CharacterEditSuccess';
+import { CharacterGetLookingListSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromLookingSuccess';
 import { CharacterGetListSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromMainSuccess';
 import { CharacterGetFromMainSuccess } from '@common/constants/swagger/domain/character/CharactersListSuccess';
 import { ConflictError } from '@common/constants/swagger/error/ConflictError';
@@ -31,6 +32,7 @@ import {
   ApiInternalServerErrorResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -41,6 +43,7 @@ import { CharacterCreateRequestDTO } from './dto/character-create.req.dto';
 import { CharacterIdParamsDTO } from './dto/character-detail.params.dto';
 import { CharacterEditRequestDTO } from './dto/character-edit.req.dto';
 import { CharacterGetFromMainResponseDTO } from './dto/character-get-from-main.res.dto';
+import { CharactersGetLookingResponseDTO } from './dto/characters-get-looking.res.dto';
 import { CharactersResponseDTO } from './dto/characters.res.dto';
 import { SortType } from './interfaces/sort-type';
 
@@ -234,6 +237,37 @@ export class CharacterController {
     );
     return ResponseEntity.OK_WITH_DATA(
       rm.READ_CHARACTER_DETAIL_SUCCESS,
+      character,
+    );
+  }
+
+  @ApiOperation({
+    summary: '둘러보기에서 캐츄를 조회합니다',
+    description: `offset 값은 아무것도 넣지 않으면 상위 100개의 캐츄를 조회함<br>만일 페이지네이션을 구현한다면 맨 처음에 0을 넣어 요청후, 이후로는 10씩 더해 추가로 요청하면 됨`,
+  })
+  @ApiOkResponse({
+    description: '둘러보기 캐츄 조회에 성공했습니다.',
+    type: CharacterGetLookingListSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Get(routesV1.character.looking)
+  @ApiQuery({ name: 'offset', required: false })
+  async getCharacterLookingList(
+    @Token() user: UserDTO,
+    @Query('offset') offset: number,
+  ): Promise<ResponseEntity<CharactersGetLookingResponseDTO[]>> {
+    const character = await this.characterService.getCharactersForLookingList(
+      offset,
+    );
+    return ResponseEntity.OK_WITH_DATA(
+      rm.READ_CHARACTERS_FROM_LOOKING_SUCCESS,
       character,
     );
   }

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -3,6 +3,7 @@ import { Character } from '@prisma/client';
 import { PrismaService } from 'src/modules/prisma/prisma.service';
 import { CharacterGetDetailResponseDTO } from './dto/character-get-detail.res.dto';
 import { CharacterGetFromMainResponseDTO } from './dto/character-get-from-main.res.dto';
+import { CharactersGetLookingResponseDTO } from './dto/characters-get-looking.res.dto';
 import { CharactersResponseDTO } from './dto/characters.res.dto';
 import { CharacterRepositoryInterface } from './interfaces/character-repository.interface';
 
@@ -256,8 +257,13 @@ export default class CharacterRepository
     return characterDetail;
   }
 
-  async getCharactersForLookingList(): Promise<any> {
+  async getCharactersForLookingList(
+    offset: number,
+    limit: number,
+  ): Promise<CharactersGetLookingResponseDTO[]> {
     const characters = await this.prisma.character.findMany({
+      skip: offset,
+      take: limit,
       select: {
         id: true,
         name: true,
@@ -278,8 +284,8 @@ export default class CharacterRepository
         },
       },
     });
-    console.info(characters);
-    return;
+
+    return characters;
   }
 
   async delete(characterId: number): Promise<void> {

--- a/src/modules/v1/character/character.service.ts
+++ b/src/modules/v1/character/character.service.ts
@@ -126,7 +126,18 @@ export class CharacterService {
     const character = await this.characterRepository.findCharacterDetailWithId(
       characterId,
     );
-    await this.characterRepository.getCharactersForLookingList();
+
+    return character;
+  }
+
+  async getCharactersForLookingList(offset: number) {
+    let limit = 10;
+    if (!offset) {
+      offset = 0;
+      limit = 100;
+    }
+    const character =
+      await this.characterRepository.getCharactersForLookingList(offset, limit);
 
     return character;
   }

--- a/src/modules/v1/character/dto/characters-get-looking.res.dto.ts
+++ b/src/modules/v1/character/dto/characters-get-looking.res.dto.ts
@@ -1,0 +1,35 @@
+import { ActivityDto } from '@modules/v1/activity/dto/activity.dto';
+import { UserDTO } from '@modules/v1/user/dto/user.dto';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { CharacterDTO } from './character.dto';
+
+class UserDataForLookingResponseDTO extends PickType(UserDTO, [
+  'id',
+  'nickname',
+]) {}
+
+class ActivityDataForLookingResponseDTO extends PickType(ActivityDto, [
+  'id',
+  'content',
+  'image',
+  'date',
+]) {}
+
+export class CharactersGetLookingResponseDTO extends PickType(CharacterDTO, [
+  'id',
+  'name',
+  'type',
+  'level',
+]) {
+  @ApiProperty({
+    description: '캐츄의 유져 정보',
+    type: UserDataForLookingResponseDTO,
+  })
+  User: UserDataForLookingResponseDTO;
+
+  @ApiProperty({
+    description: '캐츄의 가장 최근 활동 정보',
+    type: [ActivityDataForLookingResponseDTO],
+  })
+  Activity: ActivityDataForLookingResponseDTO[];
+}

--- a/src/modules/v1/character/interfaces/character-repository.interface.ts
+++ b/src/modules/v1/character/interfaces/character-repository.interface.ts
@@ -1,6 +1,7 @@
 import BaseRepositoryInterface from '@common/interfaces/base-repository.interface';
 import { Character } from '@prisma/client';
 import { CharacterGetFromMainResponseDTO } from '../dto/character-get-from-main.res.dto';
+import { CharactersGetLookingResponseDTO } from '../dto/characters-get-looking.res.dto';
 import { CharactersResponseDTO } from '../dto/characters.res.dto';
 
 export const CHARACTER_REPOSITORY = 'CHARACTER REPOSITORY';
@@ -42,7 +43,10 @@ export interface CharacterRepositoryInterface
   findCharacterDetailWithId(
     characterId: number,
   ): Promise<CharactersResponseDTO>;
-  getCharactersForLookingList(): Promise<any>;
+  getCharactersForLookingList(
+    offset: number,
+    limit: number,
+  ): Promise<CharactersGetLookingResponseDTO[]>;
 
   delete(characterId: number): Promise<void>;
 }


### PR DESCRIPTION
## 📦 Summary
- 캐츄 둘러보기 API 구현

<br>

## ✔️ Changed
- 둘러보기 창에서 캐릭터를 조회하기 위한 API를 구현했습니다.
- 페이지네이션이 구현될 것을 감안하여, query param으로 offset이라는 값을 받도록 구현하였습니다. 아무런 값을 담아 보내지 않는 경우엔 100개의 캐츄를 한번에 조회하고, 페이지네이션을 구현하는 경우 offset에 0부터 시작하여 조회할때마다 10씩 더해 query에 담아 요청합니다