### PR TITLE
[feat] 캘린더 관련 캐츄 조회 작업

### DIFF
--- a/src/common/constants/responseMessage.ts
+++ b/src/common/constants/responseMessage.ts
@@ -72,4 +72,6 @@ export default {
   READ_CHARACTER_DETAIL_SUCCESS: '캐츄 정보 조회 성공',
   READ_CHARACTERS_FROM_LOOKING_SUCCESS: '캐츄 둘러보기 목록 조회 성공',
   NO_ACCESS_DELETE_CHARACTER: '다른 유저의 캐츄는 삭제할 수 없습니다.',
+  READ_CALENDER_CHARACTER_SUCCESS: '캘린더 리포트 캐츄 목록 조회 성공',
+  READ_SPECIFIC_DATE_CHARACTER_SUCCESS: '특정 일자 캐츄 조회 성공',
 };

--- a/src/common/constants/swagger/domain/character/CharacterGetFromCalenderSuccess.ts
+++ b/src/common/constants/swagger/domain/character/CharacterGetFromCalenderSuccess.ts
@@ -9,7 +9,7 @@ export class CharacterGetCalenderSuccess extends PickType(OK_TYPE, [
   @ApiProperty({
     type: 'string',
     title: '성공 메시지',
-    example: '캘린더 조회에 성공했습니다',
+    example: '캘린더 리포트 캐츄 목록 조회 성공',
   })
   message: string;
 

--- a/src/common/constants/swagger/domain/character/CharacterGetFromCalenderSuccess.ts
+++ b/src/common/constants/swagger/domain/character/CharacterGetFromCalenderSuccess.ts
@@ -1,0 +1,21 @@
+import { CharacterGetCalenderResponseDTO } from '@modules/v1/character/dto/character-get-calender.res.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class CharacterGetCalenderSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '캘린더 조회에 성공했습니다',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: CharacterGetCalenderResponseDTO,
+    title: '캘린더 조회 정보 ',
+  })
+  data: CharacterGetCalenderResponseDTO;
+}

--- a/src/common/constants/swagger/domain/character/CharacterGetFromSpecificDateSuccess.ts
+++ b/src/common/constants/swagger/domain/character/CharacterGetFromSpecificDateSuccess.ts
@@ -1,0 +1,21 @@
+import { CharacterGetSpecificDateResponseDTO } from '@modules/v1/character/dto/character-get-specificDate.res.dto';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { OK_TYPE } from 'src/common/constants';
+
+@ApiExtraModels()
+export class CharacterGetSpecificDateSuccess extends PickType(OK_TYPE, [
+  'status',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '특정 일자 캐츄 조회 성공',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: CharacterGetSpecificDateResponseDTO,
+    title: '특정 일자 캐릭터 조회 정보 ',
+  })
+  data: CharacterGetSpecificDateResponseDTO;
+}

--- a/src/config/routes.config.ts
+++ b/src/config/routes.config.ts
@@ -23,8 +23,6 @@ export const routesV1 = {
 
   activity: {
     root: ACTIVITY_ROOT,
-    calender: `/${ACTIVITY_ROOT}/`,
-    specificDate: `/${ACTIVITY_ROOT}/:date`,
     character: `/${ACTIVITY_ROOT}/character/:character_id`,
     create: `/${ACTIVITY_ROOT}/`,
     update: `/${ACTIVITY_ROOT}/:activity_id`,
@@ -40,6 +38,8 @@ export const routesV1 = {
     looking: `/${CHARACTER_ROOT}/looking`,
     list: `/${CHARACTER_ROOT}/list`,
     detail: `/${CHARACTER_ROOT}/detail/:character_id`,
+    calender: `/${CHARACTER_ROOT}/calender`,
+    specificDate: `/${CHARACTER_ROOT}/:date`,
     delete: `/${CHARACTER_ROOT}/:character_id`,
   },
 } as const;

--- a/src/modules/v1/activity/activity.controller.ts
+++ b/src/modules/v1/activity/activity.controller.ts
@@ -53,64 +53,6 @@ dayjs.extend(CustomParseFormat);
 export class ActivityController {
   constructor(private readonly activityService: ActivityService) {}
 
-  // todo 체크 필요
-  @ApiOperation({
-    summary: '날짜 범위 내의 캘린더 데이터를 조회합니다.',
-    description: ``,
-  })
-  @ApiOkResponse({
-    description: '캘린더 조회에 성공했습니다.',
-    type: ActivityCharacterGetSuccess,
-  })
-  @ApiUnauthorizedResponse({
-    description: '인증 되지 않은 요청입니다.',
-    type: UnauthorizedError,
-  })
-  @ApiInternalServerErrorResponse({
-    description: '서버 내부 오류',
-    type: InternalServerError,
-  })
-  @Get(routesV1.activity.calender)
-  async getCalendar(
-    @Token() user: UserDTO,
-    @Query() query: ActivityQueryDTO,
-  ): Promise<ResponseEntity<any>> {
-    const data = await this.activityService.getCalender(
-      user.id,
-      query.startDate,
-      query.endDate,
-    );
-    return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
-  }
-
-  // todo 체크 필요
-  @ApiOperation({
-    summary: '특정 일자의 캐츄를 조회합니다.',
-    description: ``,
-  })
-  @ApiOkResponse({
-    description: '캘린더 조회에 성공했습니다.',
-  })
-  @ApiUnauthorizedResponse({
-    description: '인증 되지 않은 요청입니다.',
-    type: UnauthorizedError,
-  })
-  @ApiInternalServerErrorResponse({
-    description: '서버 내부 오류',
-    type: InternalServerError,
-  })
-  @Get(routesV1.activity.specificDate)
-  async getSpecificDate(
-    @Token() user: UserDTO,
-    @Param() params: ActivityDateParamsDTO,
-  ): Promise<ResponseEntity<any>> {
-    const data = await this.activityService.getSpecificDate(
-      user.id,
-      params.date,
-    );
-    return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
-  }
-
   @ApiOperation({
     summary: '특정 캐츄의 활동들을 조회합니다.',
     description: `

--- a/src/modules/v1/activity/activity.repository.ts
+++ b/src/modules/v1/activity/activity.repository.ts
@@ -51,11 +51,12 @@ export class ActivityRepository implements ActivityRepositoryInterface {
       where: {
         user_id: userId,
         date: {
-          lte: startDate,
-          gte: endDate,
+          gte: startDate,
+          lte: endDate,
         },
         is_delete: false,
       },
+      // include: { Character: true },
     });
   }
 

--- a/src/modules/v1/activity/activity.repository.ts
+++ b/src/modules/v1/activity/activity.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Activity } from '@prisma/client';
+import dayjs from 'dayjs';
 import { PrismaService } from 'src/modules/prisma/prisma.service';
 import { ActivityRepositoryInterface } from './interfaces/activity-repository.interface';
 
@@ -23,11 +24,11 @@ export class ActivityRepository implements ActivityRepositoryInterface {
     });
   }
 
-  async findByDate(userId: number, date: Date): Promise<Activity> {
-    return await this.prisma.activity.findFirst({
+  async findByDate(userId: number, date: Date): Promise<Activity[]> {
+    return await this.prisma.activity.findMany({
       where: {
         user_id: userId,
-        date,
+        date: { gte: date, lt: dayjs(date).add(1, 'day').toDate() },
         is_delete: false,
       },
     });

--- a/src/modules/v1/activity/activity.repository.ts
+++ b/src/modules/v1/activity/activity.repository.ts
@@ -56,7 +56,6 @@ export class ActivityRepository implements ActivityRepositoryInterface {
         },
         is_delete: false,
       },
-      // include: { Character: true },
     });
   }
 

--- a/src/modules/v1/activity/activity.service.ts
+++ b/src/modules/v1/activity/activity.service.ts
@@ -18,11 +18,6 @@ export class ActivityService {
     private readonly activityRepository: ActivityRepositoryInterface,
   ) {}
 
-  async getSpecificDate(userId: number, date: string) {
-    const target = dayjs(date, 'YYYYMMDD').add(9, 'h').toDate();
-    return await this.activityRepository.findByDate(userId, target);
-  }
-
   async getActivitiesByCharacterId(characterId: number) {
     return await this.activityRepository.findByCharacterId(characterId);
   }

--- a/src/modules/v1/activity/activity.service.ts
+++ b/src/modules/v1/activity/activity.service.ts
@@ -18,16 +18,6 @@ export class ActivityService {
     private readonly activityRepository: ActivityRepositoryInterface,
   ) {}
 
-  async getCalender(userId: number, startDate: string, endDate: string) {
-    const start = dayjs(startDate, 'YYYYMMDD').add(9, 'h').toDate();
-    const end = dayjs(endDate, 'YYYYMMDD').add(9, 'h').toDate();
-    return await this.activityRepository.findBetweenDateAndDate(
-      userId,
-      start,
-      end,
-    );
-  }
-
   async getSpecificDate(userId: number, date: string) {
     const target = dayjs(date, 'YYYYMMDD').add(9, 'h').toDate();
     return await this.activityRepository.findByDate(userId, target);

--- a/src/modules/v1/activity/interfaces/activity-repository.interface.ts
+++ b/src/modules/v1/activity/interfaces/activity-repository.interface.ts
@@ -5,7 +5,7 @@ export const ACTIVITY_REPOSITORY = 'ACTIVITY REPOSITORY';
 
 export interface ActivityRepositoryInterface
   extends BaseRepositoryInterface<Activity> {
-  findByDate(userId: number, date: Date): Promise<Activity>;
+  findByDate(userId: number, date: Date): Promise<Activity[]>;
   findBetweenDateAndDate(
     userId: number,
     startDate: Date,

--- a/src/modules/v1/character/character.controller.ts
+++ b/src/modules/v1/character/character.controller.ts
@@ -6,6 +6,7 @@ import { CharacterEditSuccess } from '@common/constants/swagger/domain/character
 import { CharacterGetCalenderSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromCalenderSuccess';
 import { CharacterGetLookingListSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromLookingSuccess';
 import { CharacterGetListSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromMainSuccess';
+import { CharacterGetSpecificDateSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromSpecificDateSuccess';
 import { CharacterGetFromMainSuccess } from '@common/constants/swagger/domain/character/CharactersListSuccess';
 import { ConflictError } from '@common/constants/swagger/error/ConflictError';
 import { InternalServerError } from '@common/constants/swagger/error/InternalServerError';
@@ -37,6 +38,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { ActivityDateParamsDTO } from '../activity/dto/activity-date.params.dto';
 import { ActivityQueryDTO } from '../activity/dto/activity.query.dto';
 import { UserDTO } from '../user/dto/user.dto';
 import { CharacterService } from './character.service';
@@ -46,6 +48,7 @@ import { CharacterIdParamsDTO } from './dto/character-detail.params.dto';
 import { CharacterEditRequestDTO } from './dto/character-edit.req.dto';
 import { CharacterGetCalenderResponseDTO } from './dto/character-get-calender.res.dto';
 import { CharacterGetFromMainResponseDTO } from './dto/character-get-from-main.res.dto';
+import { CharacterGetSpecificDateResponseDTO } from './dto/character-get-specificDate.res.dto';
 import { CharactersGetLookingResponseDTO } from './dto/characters-get-looking.res.dto';
 import { CharactersResponseDTO } from './dto/characters.res.dto';
 import { SortType } from './interfaces/sort-type';
@@ -304,7 +307,6 @@ export class CharacterController {
     return ResponseEntity.OK_WITH(rm.DELETE_CHARACTER_SUCCESS);
   }
 
-  // todo 체크 필요
   @ApiOperation({
     summary: '날짜 범위 내의 캘린더 데이터를 조회합니다.',
     description: ``,
@@ -331,33 +333,40 @@ export class CharacterController {
       query.startDate,
       query.endDate,
     );
-    return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
+    return ResponseEntity.OK_WITH_DATA(
+      rm.READ_CALENDER_CHARACTER_SUCCESS,
+      data,
+    );
   }
 
-  // @ApiOperation({
-  //   summary: '특정 일자의 캐츄를 조회합니다.',
-  //   description: ``,
-  // })
-  // @ApiOkResponse({
-  //   description: '캘린더 조회에 성공했습니다.',
-  // })
-  // @ApiUnauthorizedResponse({
-  //   description: '인증 되지 않은 요청입니다.',
-  //   type: UnauthorizedError,
-  // })
-  // @ApiInternalServerErrorResponse({
-  //   description: '서버 내부 오류',
-  //   type: InternalServerError,
-  // })
-  // @Get(routesV1.activity.specificDate)
-  // async getSpecificDate(
-  //   @Token() user: UserDTO,
-  //   @Param() params: ActivityDateParamsDTO,
-  // ): Promise<ResponseEntity<any>> {
-  //   const data = await this.activityService.getSpecificDate(
-  //     user.id,
-  //     params.date,
-  //   );
-  //   return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
-  // }
+  @ApiOperation({
+    summary: '특정 일자의 캐츄를 조회합니다.',
+    description: ``,
+  })
+  @ApiOkResponse({
+    description: '특정 일자의 캐츄를 조회에 성공했습니다.',
+    type: CharacterGetSpecificDateSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Get(routesV1.character.specificDate)
+  async getSpecificDate(
+    @Token() user: UserDTO,
+    @Param() params: ActivityDateParamsDTO,
+  ): Promise<ResponseEntity<CharacterGetSpecificDateResponseDTO[]>> {
+    const data = await this.characterService.getSpecificDate(
+      user.id,
+      params.date,
+    );
+    return ResponseEntity.OK_WITH_DATA(
+      rm.READ_SPECIFIC_DATE_CHARACTER_SUCCESS,
+      data,
+    );
+  }
 }

--- a/src/modules/v1/character/character.controller.ts
+++ b/src/modules/v1/character/character.controller.ts
@@ -36,6 +36,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { ActivityQueryDTO } from '../activity/dto/activity.query.dto';
 import { UserDTO } from '../user/dto/user.dto';
 import { CharacterService } from './character.service';
 import { CharacterBlockRequestDTO } from './dto/character-block.req.dto';
@@ -300,4 +301,61 @@ export class CharacterController {
     await this.characterService.deleteCharacter(user.id, params.character_id);
     return ResponseEntity.OK_WITH(rm.DELETE_CHARACTER_SUCCESS);
   }
+
+  // todo 체크 필요
+  @ApiOperation({
+    summary: '날짜 범위 내의 캘린더 데이터를 조회합니다.',
+    description: ``,
+  })
+  @ApiOkResponse({
+    description: '캘린더 조회에 성공했습니다.',
+    // type: ActivityCharacterGetSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '인증 되지 않은 요청입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '서버 내부 오류',
+    type: InternalServerError,
+  })
+  @Get(routesV1.character.calender)
+  async getCalendar(
+    @Token() user: UserDTO,
+    @Query() query: ActivityQueryDTO,
+  ): Promise<ResponseEntity<any>> {
+    const data = await this.characterService.getCalender(
+      user.id,
+      query.startDate,
+      query.endDate,
+    );
+    return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
+  }
+
+  // @ApiOperation({
+  //   summary: '특정 일자의 캐츄를 조회합니다.',
+  //   description: ``,
+  // })
+  // @ApiOkResponse({
+  //   description: '캘린더 조회에 성공했습니다.',
+  // })
+  // @ApiUnauthorizedResponse({
+  //   description: '인증 되지 않은 요청입니다.',
+  //   type: UnauthorizedError,
+  // })
+  // @ApiInternalServerErrorResponse({
+  //   description: '서버 내부 오류',
+  //   type: InternalServerError,
+  // })
+  // @Get(routesV1.activity.specificDate)
+  // async getSpecificDate(
+  //   @Token() user: UserDTO,
+  //   @Param() params: ActivityDateParamsDTO,
+  // ): Promise<ResponseEntity<any>> {
+  //   const data = await this.activityService.getSpecificDate(
+  //     user.id,
+  //     params.date,
+  //   );
+  //   return ResponseEntity.OK_WITH_DATA(rm.READ_ACTIVITY_SUCCESS, data);
+  // }
 }

--- a/src/modules/v1/character/character.controller.ts
+++ b/src/modules/v1/character/character.controller.ts
@@ -3,6 +3,7 @@ import { ResponseEntity } from '@common/constants/responseEntity';
 import { CharacterBlockSuccess } from '@common/constants/swagger/domain/character/CharacterBlockSuccess';
 import { CharacterCreateSuccess } from '@common/constants/swagger/domain/character/CharacterCreateSuccess';
 import { CharacterEditSuccess } from '@common/constants/swagger/domain/character/CharacterEditSuccess';
+import { CharacterGetCalenderSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromCalenderSuccess';
 import { CharacterGetLookingListSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromLookingSuccess';
 import { CharacterGetListSuccess } from '@common/constants/swagger/domain/character/CharacterGetFromMainSuccess';
 import { CharacterGetFromMainSuccess } from '@common/constants/swagger/domain/character/CharactersListSuccess';
@@ -43,6 +44,7 @@ import { CharacterBlockRequestDTO } from './dto/character-block.req.dto';
 import { CharacterCreateRequestDTO } from './dto/character-create.req.dto';
 import { CharacterIdParamsDTO } from './dto/character-detail.params.dto';
 import { CharacterEditRequestDTO } from './dto/character-edit.req.dto';
+import { CharacterGetCalenderResponseDTO } from './dto/character-get-calender.res.dto';
 import { CharacterGetFromMainResponseDTO } from './dto/character-get-from-main.res.dto';
 import { CharactersGetLookingResponseDTO } from './dto/characters-get-looking.res.dto';
 import { CharactersResponseDTO } from './dto/characters.res.dto';
@@ -309,7 +311,7 @@ export class CharacterController {
   })
   @ApiOkResponse({
     description: '캘린더 조회에 성공했습니다.',
-    // type: ActivityCharacterGetSuccess,
+    type: CharacterGetCalenderSuccess,
   })
   @ApiUnauthorizedResponse({
     description: '인증 되지 않은 요청입니다.',
@@ -323,7 +325,7 @@ export class CharacterController {
   async getCalendar(
     @Token() user: UserDTO,
     @Query() query: ActivityQueryDTO,
-  ): Promise<ResponseEntity<any>> {
+  ): Promise<ResponseEntity<CharacterGetCalenderResponseDTO>> {
     const data = await this.characterService.getCalender(
       user.id,
       query.startDate,

--- a/src/modules/v1/character/character.controller.ts
+++ b/src/modules/v1/character/character.controller.ts
@@ -309,7 +309,10 @@ export class CharacterController {
 
   @ApiOperation({
     summary: '날짜 범위 내의 캘린더 데이터를 조회합니다.',
-    description: ``,
+    description: `
+    YYYYMMDD의 형식으로, 날짜 범위를 입력받습니다.\n
+    해당 날짜의 범위에 활동이 있는 캐츄들의 정보를 전달받습니다.\n
+    `,
   })
   @ApiOkResponse({
     description: '캘린더 조회에 성공했습니다.',
@@ -341,7 +344,10 @@ export class CharacterController {
 
   @ApiOperation({
     summary: '특정 일자의 캐츄를 조회합니다.',
-    description: ``,
+    description: `
+    YYYYMMDD의 형식으로, 특정날짜를 입력받습니다.\n
+    해당 날짜에 활동이 있는 모든 캐츄의 목록을 조회합니다\n
+    `,
   })
   @ApiOkResponse({
     description: '특정 일자의 캐츄를 조회에 성공했습니다.',

--- a/src/modules/v1/character/character.module.ts
+++ b/src/modules/v1/character/character.module.ts
@@ -1,4 +1,6 @@
 import { Logger, Module } from '@nestjs/common';
+import { ActivityRepository } from '../activity/activity.repository';
+import { ACTIVITY_REPOSITORY } from '../activity/interfaces/activity-repository.interface';
 import BlockRepository from '../block/block.repository';
 import { BLOCK_REPOSITORY } from '../block/interface/block-repository.interface';
 
@@ -15,11 +17,16 @@ const BlockRepositoryProvider = {
   provide: BLOCK_REPOSITORY,
   useClass: BlockRepository,
 };
+const ActivityRepositoryProvider = {
+  provide: ACTIVITY_REPOSITORY,
+  useClass: ActivityRepository,
+};
 @Module({
   controllers: [CharacterController],
   providers: [
     ClientRepositoryProvider,
     BlockRepositoryProvider,
+    ActivityRepositoryProvider,
     CharacterService,
     Logger,
   ],

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -21,6 +21,14 @@ export default class CharacterRepository
     });
   }
 
+  async findByUserId(userId: number): Promise<Character[]> {
+    return await this.prisma.character.findMany({
+      where: {
+        user_id: userId,
+      },
+    });
+  }
+
   async findAll(): Promise<Character[]> {
     return await this.prisma.character.findMany();
   }

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -28,7 +28,7 @@ export default class CharacterRepository
     });
   }
 
-  async findByUserId(userId: number): Promise<Character[]> {
+  async findAllCharacterByUserId(userId: number): Promise<Character[]> {
     return await this.prisma.character.findMany({
       where: {
         user_id: userId,

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -20,6 +20,13 @@ export default class CharacterRepository
       },
     });
   }
+  async findManyForDailyCharacter(ids: number[]): Promise<Character[]> {
+    return await this.prisma.character.findMany({
+      where: {
+        id: { in: ids },
+      },
+    });
+  }
 
   async findByUserId(userId: number): Promise<Character[]> {
     return await this.prisma.character.findMany({
@@ -316,4 +323,7 @@ export default class CharacterRepository
       },
     });
   }
+}
+function In(ids: number[]): any {
+  throw new Error('Function not implemented.');
 }

--- a/src/modules/v1/character/character.service.ts
+++ b/src/modules/v1/character/character.service.ts
@@ -16,6 +16,8 @@ import {
   ACTIVITY_REPOSITORY,
 } from '../activity/interfaces/activity-repository.interface';
 import _ from 'lodash';
+import { DailyCharacterDataForCalenderResponseDTO } from './dto/character-get-calender.res.dto';
+import { Character } from '@prisma/client';
 
 @Injectable()
 export class CharacterService {
@@ -208,7 +210,7 @@ export class CharacterService {
     /**
      * 일자별 캐츄를 찾는 작업
      */
-    const daily = [];
+    const daily: DailyCharacterDataForCalenderResponseDTO[] = [];
     for (const day in dailyActivities) {
       const dailyCount = _.countBy(dailyActivities[day], 'character_id');
 
@@ -218,12 +220,13 @@ export class CharacterService {
 
       const characterData = character[dailyCharacterId][0];
       daily.push({
-        day: day,
+        day: parseInt(day),
         id: characterData.id,
         type: characterData.type,
         level: characterData.level,
       });
     }
+
     return { monthly, daily };
   }
 }

--- a/src/modules/v1/character/character.service.ts
+++ b/src/modules/v1/character/character.service.ts
@@ -172,7 +172,7 @@ export class CharacterService {
     );
 
     const character = _.groupBy(
-      await this.characterRepository.findByUserId(userId),
+      await this.characterRepository.findAllCharacterByUserId(userId),
       'id',
     );
 

--- a/src/modules/v1/character/dto/character-get-calender.res.dto.ts
+++ b/src/modules/v1/character/dto/character-get-calender.res.dto.ts
@@ -1,0 +1,34 @@
+import { ActivityDto } from '@modules/v1/activity/dto/activity.dto';
+import { UserDTO } from '@modules/v1/user/dto/user.dto';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { CharacterDTO } from './character.dto';
+
+class MonthlyCharacterDataForCalenderResponseDTO extends PickType(
+  CharacterDTO,
+  ['id', 'name', 'type', 'level'],
+) {
+  @ApiProperty({ description: '해당 캐츄의 이달의 활동 수', example: 10 })
+  catching: number;
+}
+
+export class DailyCharacterDataForCalenderResponseDTO extends PickType(
+  CharacterDTO,
+  ['id', 'type', 'level'],
+) {
+  @ApiProperty({ description: '일자 정보', example: 1 })
+  day: number;
+}
+
+export class CharacterGetCalenderResponseDTO {
+  @ApiProperty({
+    description: '이달의 캐츄의 정보',
+    type: MonthlyCharacterDataForCalenderResponseDTO,
+  })
+  monthly: MonthlyCharacterDataForCalenderResponseDTO;
+
+  @ApiProperty({
+    description: '일자별 캐츄 정보',
+    type: [DailyCharacterDataForCalenderResponseDTO],
+  })
+  daily: DailyCharacterDataForCalenderResponseDTO[];
+}

--- a/src/modules/v1/character/dto/character-get-specificDate.res.dto.ts
+++ b/src/modules/v1/character/dto/character-get-specificDate.res.dto.ts
@@ -1,0 +1,7 @@
+import { PickType } from '@nestjs/swagger';
+import { CharacterDTO } from './character.dto';
+
+export class CharacterGetSpecificDateResponseDTO extends PickType(
+  CharacterDTO,
+  ['id', 'name', 'type', 'level'],
+) {}

--- a/src/modules/v1/character/interfaces/character-repository.interface.ts
+++ b/src/modules/v1/character/interfaces/character-repository.interface.ts
@@ -8,7 +8,7 @@ export const CHARACTER_REPOSITORY = 'CHARACTER REPOSITORY';
 
 export interface CharacterRepositoryInterface
   extends BaseRepositoryInterface<Character> {
-  findByUserId(userId: number): Promise<Character[]>;
+  findAllCharacterByUserId(userId: number): Promise<Character[]>;
 
   findManyForDailyCharacter(ids: number[]): Promise<Character[]>;
 

--- a/src/modules/v1/character/interfaces/character-repository.interface.ts
+++ b/src/modules/v1/character/interfaces/character-repository.interface.ts
@@ -10,6 +10,8 @@ export interface CharacterRepositoryInterface
   extends BaseRepositoryInterface<Character> {
   findByUserId(userId: number): Promise<Character[]>;
 
+  findManyForDailyCharacter(ids: number[]): Promise<Character[]>;
+
   findByCharacterNameAndUserId(
     userId: number,
     name: string,

--- a/src/modules/v1/character/interfaces/character-repository.interface.ts
+++ b/src/modules/v1/character/interfaces/character-repository.interface.ts
@@ -8,6 +8,8 @@ export const CHARACTER_REPOSITORY = 'CHARACTER REPOSITORY';
 
 export interface CharacterRepositoryInterface
   extends BaseRepositoryInterface<Character> {
+  findByUserId(userId: number): Promise<Character[]>;
+
   findByCharacterNameAndUserId(
     userId: number,
     name: string,


### PR DESCRIPTION
## 📦 Summary
- 캘린더 리포트 캐츄 목록 조회 API 구현
- 특정 일자 캐츄  조회 API 구현

<br>

## ✔️ Changed
- 캐츄 조회이지만 기준은 활동 시간이기에, service에서 activity repository의 메소드를 inject하는 식으로 작업 진행