### PR TITLE
[fix] 둘러보기 response 형식 수정 및 캐치 지수 업데이트 안되는 문제 해결

### DIFF
--- a/src/modules/v1/activity/interfaces/activity-repository.interface.ts
+++ b/src/modules/v1/activity/interfaces/activity-repository.interface.ts
@@ -5,7 +5,7 @@ export const ACTIVITY_REPOSITORY = 'ACTIVITY REPOSITORY';
 
 export interface ActivityRepositoryInterface
   extends BaseRepositoryInterface<ActivityDto> {
-  findByDate(userId: number, date: Date): Promise<ActivityDto>;
+  findByDate(userId: number, date: Date): Promise<ActivityDto[]>;
   findAllBetweenDateAndDate(
     userId: number,
     startDate: Date,

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -109,15 +109,6 @@ export default class CharacterRepository
       },
     });
 
-    const userActivityCount = await this.prisma.activity.count({
-      where: {
-        is_delete: false,
-        Character: {
-          user_id,
-        },
-      },
-    });
-
     const result = characters.reduce(
       (acc, character) => {
         const characterInfo = {

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -219,9 +219,8 @@ export default class CharacterRepository
     return characters;
   }
 
-  async findCharacterDetailWithId(
-    characterId: number,
-  ): Promise<CharacterGetDetailResponseDTO> {
+  async findCharacterDetailWithId(characterId: number): Promise<any> {
+    // CharacterGetDetailResponseDTO
     const character = await this.prisma.character.findFirst({
       select: {
         id: true,
@@ -231,33 +230,30 @@ export default class CharacterRepository
         is_public: true,
         user_id: true,
         created_at: true,
-
-        _count: {
-          select: { Activity: true },
-        },
       },
       where: {
         id: characterId,
       },
     });
 
-    const characters = await this.prisma.character.findMany({
-      select: {
-        _count: {
-          select: { Activity: true },
-        },
-      },
+    const characterActicitycount = await this.prisma.activity.count({
       where: {
-        user_id: character.user_id,
+        character_id: character.id,
+        is_delete: false,
       },
     });
-    const totalActivityCount = characters.reduce((acc, cur) => {
-      acc += cur._count.Activity;
-      return acc;
-    }, 0);
+
+    const userActivityCount = await this.prisma.activity.count({
+      where: {
+        is_delete: false,
+        Character: {
+          user_id: character.user_id,
+        },
+      },
+    });
 
     const catchu_rate = Math.round(
-      (character._count.Activity / totalActivityCount) * 100,
+      (characterActicitycount / userActivityCount) * 100,
     );
 
     const characterDetail = {
@@ -267,7 +263,7 @@ export default class CharacterRepository
       level: character.level,
       is_public: character.is_public,
       created_at: character.created_at,
-      activity_count: character._count.Activity,
+      activity_count: characterActicitycount,
       cachu_rate: isNaN(catchu_rate) ? 0 : catchu_rate,
     };
 

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Character } from '@prisma/client';
+import dayjs from 'dayjs';
+import { add } from 'lodash';
 import { PrismaService } from 'src/modules/prisma/prisma.service';
 import { CharacterGetDetailResponseDTO } from './dto/character-get-detail.res.dto';
 import { CharacterGetFromMainResponseDTO } from './dto/character-get-from-main.res.dto';
@@ -300,7 +302,21 @@ export default class CharacterRepository
       },
     });
 
-    return characters;
+    const result = characters
+      .filter((character) => character.Activity.length > 0)
+      .map((character) => {
+        const formattedActivity = {
+          ...character.Activity[0],
+          date: dayjs(character.Activity[0].date).format('YYYYMMDDHHmmss'),
+        };
+
+        return {
+          ...character,
+          Activity: formattedActivity,
+        };
+      });
+
+    return result;
   }
 
   async delete(characterId: number): Promise<void> {

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -101,7 +101,20 @@ export default class CharacterRepository
         user_id,
       },
       include: {
-        Activity: true,
+        Activity: {
+          where: {
+            is_delete: false,
+          },
+        },
+      },
+    });
+
+    const userActivityCount = await this.prisma.activity.count({
+      where: {
+        is_delete: false,
+        Character: {
+          user_id,
+        },
       },
     });
 
@@ -219,8 +232,9 @@ export default class CharacterRepository
     return characters;
   }
 
-  async findCharacterDetailWithId(characterId: number): Promise<any> {
-    // CharacterGetDetailResponseDTO
+  async findCharacterDetailWithId(
+    characterId: number,
+  ): Promise<CharacterGetDetailResponseDTO> {
     const character = await this.prisma.character.findFirst({
       select: {
         id: true,

--- a/src/modules/v1/character/character.service.ts
+++ b/src/modules/v1/character/character.service.ts
@@ -165,7 +165,7 @@ export class CharacterService {
     const start = dayjs(startDate, 'YYYYMMDD').add(9, 'h').toDate();
     const end = dayjs(endDate, 'YYYYMMDD').add(9, 'h').toDate();
 
-    const activity = await this.activityRepository.findBetweenDateAndDate(
+    const activity = await this.activityRepository.findAllBetweenDateAndDate(
       userId,
       start,
       end,

--- a/src/modules/v1/character/dto/characters-get-looking.res.dto.ts
+++ b/src/modules/v1/character/dto/characters-get-looking.res.dto.ts
@@ -12,8 +12,12 @@ class ActivityDataForLookingResponseDTO extends PickType(ActivityDto, [
   'id',
   'content',
   'image',
-  'date',
-]) {}
+]) {
+  @ApiProperty({
+    description: '활동의 날짜(YYYYMMDDHHmmss',
+  })
+  date: string;
+}
 
 export class CharactersGetLookingResponseDTO extends PickType(CharacterDTO, [
   'id',
@@ -31,5 +35,5 @@ export class CharactersGetLookingResponseDTO extends PickType(CharacterDTO, [
     description: '캐츄의 가장 최근 활동 정보',
     type: [ActivityDataForLookingResponseDTO],
   })
-  Activity: ActivityDataForLookingResponseDTO[];
+  Activity: ActivityDataForLookingResponseDTO;
 }


### PR DESCRIPTION
## 📦 Summary
- 둘러보기 api에서 Activity 안에 date 형식을 YYYYMMDDHHMMSS로 수정
- 둘러보기 api에서 response에 activity 빈 값인 경우 필터링
- 캐츄 메인 조회, 캐츄 정보 조회시 catchu rate 반영 안되는 문제 해결

<br>

## ✔️ Changed
