### PR TITLE
[fix] 캐릭터 조회 관련 문제 해결 

### DIFF
--- a/src/modules/v1/activity/activity.repository.ts
+++ b/src/modules/v1/activity/activity.repository.ts
@@ -46,6 +46,15 @@ export class ActivityRepository implements ActivityRepositoryInterface {
     });
   }
 
+  async findAllByUserId(userId: number): Promise<ActivityDto[]> {
+    return await this.prisma.activity.findMany({
+      where: {
+        user_id: userId,
+        is_delete: false,
+      },
+    });
+  }
+
   async findAllBetweenDateAndDate(
     userId: number,
     startDate: Date,

--- a/src/modules/v1/activity/interfaces/activity-repository.interface.ts
+++ b/src/modules/v1/activity/interfaces/activity-repository.interface.ts
@@ -18,6 +18,7 @@ export interface ActivityRepositoryInterface
     limit: number,
   ): Promise<ActivityDataForLookingDTO[]>;
   findAllByCharacterId(characterId: number): Promise<ActivityDto[]>;
+  findAllByUserId(userId: number): Promise<ActivityDto[]>;
   create(
     userId: number,
     characterId: number,

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -169,7 +169,7 @@ export default class CharacterRepository
     const characters = await this.prisma.character.findMany({
       select: { id: true, name: true, type: true, level: true },
       orderBy: {
-        created_at: 'asc',
+        created_at: 'desc',
       },
       where: { user_id: userId, is_delete: false },
     });

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -98,59 +98,6 @@ export default class CharacterRepository
     return character;
   }
 
-  async findCharactersWithInfoByUserId(
-    user_id: number,
-  ): Promise<CharacterGetFromMainResponseDTO[]> {
-    const characters = await this.prisma.character.findMany({
-      where: {
-        user_id,
-        is_delete: false,
-      },
-      include: {
-        Activity: {
-          where: {
-            is_delete: false,
-          },
-        },
-      },
-    });
-
-    const result = characters.reduce(
-      (acc, character) => {
-        const characterInfo = {
-          id: character.id,
-          name: character.name,
-          type: character.type,
-          level: character.level,
-          activity_count: character.Activity.length,
-        };
-        acc.character.push(characterInfo);
-        acc.totalActivityCount += character.Activity.length;
-        return acc;
-      },
-      {
-        character: [],
-        totalActivityCount: 0,
-      },
-    );
-
-    const mainCharacters: CharacterGetFromMainResponseDTO[] =
-      result.character.reduce((acc, character) => {
-        const catchu_rate = Math.round(
-          (character.activity_count / result.totalActivityCount) * 100,
-        );
-
-        const characterInfo = {
-          ...character,
-          catchu_rate: isNaN(catchu_rate) ? 0 : catchu_rate,
-        };
-        acc.push(characterInfo);
-        return acc;
-      }, []);
-
-    return mainCharacters;
-  }
-
   async findCharactersOrderByMost(
     userId: number,
   ): Promise<CharactersResponseDTO[]> {

--- a/src/modules/v1/character/character.repository.ts
+++ b/src/modules/v1/character/character.repository.ts
@@ -244,6 +244,7 @@ export default class CharacterRepository
         id: {
           in: characterIds,
         },
+        is_public: true,
         is_delete: false,
       },
     });

--- a/src/modules/v1/character/character.service.ts
+++ b/src/modules/v1/character/character.service.ts
@@ -268,7 +268,6 @@ export class CharacterService {
     const mainMonth = +Object.keys(daysByMonth).reduce((a, b) =>
       daysByMonth[a] > daysByMonth[b] ? a : b,
     );
-
     const activity = await this.activityRepository.findAllBetweenDateAndDate(
       userId,
       start,
@@ -310,18 +309,26 @@ export class CharacterService {
     /**
      * 이 달의 캐츄를 찾는 작업
      */
-    const monthlyCharacterId = Object.keys(monthlyCharacterCount).reduce(
-      (a, b) => (monthlyCharacterCount[a] > monthlyCharacterCount[b] ? a : b),
-    );
+    const characterIdsForMonthlyCharacter = Object.keys(monthlyCharacterCount);
+    const characterIdsForMonthlyCharacterChecker =
+      characterIdsForMonthlyCharacter.length;
+    let monthlyCharacterId: string, monthlyCharacterData: Character;
+    if (characterIdsForMonthlyCharacterChecker) {
+      monthlyCharacterId = characterIdsForMonthlyCharacter.reduce((a, b) =>
+        monthlyCharacterCount[a] > monthlyCharacterCount[b] ? a : b,
+      );
+      monthlyCharacterData = character[monthlyCharacterId][0];
+    }
 
-    const monthlyCharacterData = character[monthlyCharacterId][0];
-    const monthly = {
-      id: monthlyCharacterData.id,
-      name: monthlyCharacterData.name,
-      type: monthlyCharacterData.type,
-      level: monthlyCharacterData.level,
-      catching: monthlyCharacterCount[monthlyCharacterId],
-    };
+    const monthly = characterIdsForMonthlyCharacterChecker
+      ? {
+          id: monthlyCharacterData.id,
+          name: monthlyCharacterData.name,
+          type: monthlyCharacterData.type,
+          level: monthlyCharacterData.level,
+          catching: monthlyCharacterCount[monthlyCharacterId],
+        }
+      : { id: null, name: null, type: null, level: null, catching: null };
 
     /**
      * 일자별 캐츄를 찾는 작업

--- a/src/modules/v1/character/interfaces/character-repository.interface.ts
+++ b/src/modules/v1/character/interfaces/character-repository.interface.ts
@@ -39,10 +39,6 @@ export interface CharacterRepositoryInterface
     is_public: boolean,
   ): Promise<Character>;
 
-  findCharactersWithInfoByUserId(
-    userId: number,
-  ): Promise<CharacterGetFromMainResponseDTO[]>;
-
   findCharactersOrderByMost(userId: number): Promise<CharactersResponseDTO[]>;
   findCharactersOrderByRecent(userId: number): Promise<CharactersResponseDTO[]>;
   findCharactersOrderByBirth(userId: number): Promise<CharactersResponseDTO[]>;


### PR DESCRIPTION
## 📦 Summary
- 캐릭터 조회 관련 문제 해결 



## ✔️ Changed
-  메인 뷰 최근 생성 순이 아닌 최근 기록 순으로 보이도록 수정
- 둘러보기에서 비공개 설정 한 애들만 보이는걸, 설정 안한 애들만 보이도록 수정
- 캐츄 목록 조회(최근 기록 순) 순서 잘못된 것 해결
- 캐츄 목록 조회(최근 생성 순) 역순으로 오고 있는 문제 수정
